### PR TITLE
Ip detection through 'hostname -i' is updated with 'hostname -I'

### DIFF
--- a/enterprise/client/Linux/resources/ipbinding.sh
+++ b/enterprise/client/Linux/resources/ipbinding.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-ip="$(hostname -i)"
-DESTINATION=/opt
+ip="$(hostname -I | cut -d ' ' -f 1)"
+NCHOME=/opt/ncache
 
-cd $DESTINATION/ncache/bin/service
+cd $NCHOME/bin/service
 
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s Alachisoft.NCache.Daemon.dll.config
-cd $DESTINATION/ncache/config
+
+cd $NCHOME/config
 
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s client.ncconf
-printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s config.ncconf 
-printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s bridge.ncconf 
+printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s config.ncconf
 
 rm -f /app/ipbinding.sh

--- a/enterprise/server/Linux/resources/ipbinding.sh
+++ b/enterprise/server/Linux/resources/ipbinding.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-ip="$(hostname -i)"
-DESTINATION=/opt
+ip="$(hostname -I | cut -d ' ' -f 1)"
+NCHOME=/opt/ncache
 
-cd $DESTINATION/ncache/bin/service
+cd $NCHOME/bin/service
 
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s Alachisoft.NCache.Daemon.dll.config
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s Alachisoft.NCache.BridgeDaemon.dll.config
 
-cd $DESTINATION/ncache/config
+cd $NCHOME/config
 
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s client.ncconf
-printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s config.ncconf 
-printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s bridge.ncconf 
+printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s config.ncconf
+printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s bridge.ncconf
 
 rm -f /app/ipbinding.sh

--- a/opensource/client/Linux/resources/ipbinding.sh
+++ b/opensource/client/Linux/resources/ipbinding.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-ip="$(hostname -i)"
-DESTINATION=<DESTINATION>
+ip="$(hostname -I | cut -d ' ' -f 1)"
+NCHOME=/opt/ncache
 
-cd $DESTINATION/ncache/bin/service
+cd $NCHOME/bin/service
 
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s Alachisoft.NCache.Daemon.dll.config
 
-cd $DESTINATION/ncache/config
+cd $NCHOME/config
 
 printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s client.ncconf
-printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s config.ncconf 
+printf "%s\n" ",s/<IP>/$ip/g" wq | ed -s config.ncconf
 
 rm -f /app/ipbinding.sh


### PR DESCRIPTION
-i, --ip-address
              Display the network address(es) of the host name. Note that this works only if the host name can be resolved. Avoid using this option; use hostname --all-ip-addresses instead.

-I, --all-ip-addresses
              Display all network addresses of the host. This option enumerates all configured addresses on all network interfaces. The loopback interface and IPv6 link-local addresses are omitted. Contrary to option -i, this option does not depend on name resolution. Do not make any assumptions about the order of the output.
